### PR TITLE
Fix Swagger spec parsing and add OpenSearch dependency

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -75,7 +75,7 @@ components:
         type: { type: string, nullable: true }
         plantedAt: { type: string, format: date-time, nullable: true }
         matured: { type: boolean }
-            GardenConfig:
+    GardenConfig:
       type: object
       properties:
         growthMinutes: { type: integer }
@@ -222,7 +222,7 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/Plot' }
-    /garden/config:
+  /garden/config:
     get:
       security: [{ bearerAuth: [] }]
       summary: Конфигурация грядок

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "migrate": "node src/migrate.js"
   },
   "dependencies": {
+    "@opensearch-project/opensearch": "2.13.0",
     "bcryptjs": "2.4.3",
     "cors": "2.8.5",
     "dotenv": "16.4.5",


### PR DESCRIPTION
## Summary
- fix the indentation errors in the OpenAPI schema so Swagger UI can load it
- add the OpenSearch client dependency required by the backend logger

## Testing
- `npm install` *(fails: 403 Forbidden fetching @opensearch-project/opensearch)*

------
https://chatgpt.com/codex/tasks/task_e_68cb965da340832089ed547a98302dbc