### PR TITLE
Persist profile level in database

### DIFF
--- a/backend/migrations/004_add_level_column.sql
+++ b/backend/migrations/004_add_level_column.sql
@@ -1,0 +1,5 @@
+ALTER TABLE profiles
+  ADD COLUMN level INT NOT NULL DEFAULT 1 AFTER sold_count;
+
+UPDATE profiles
+SET level = CASE WHEN sold_count >= 50 THEN 2 ELSE 1 END;

--- a/backend/src/routes/profile.js
+++ b/backend/src/routes/profile.js
@@ -16,6 +16,7 @@ const DEFAULT_PROFILE = {
   passport: null,
   balance: 30,
   sold_count: 0,
+  level: 1,
   yogurt_ml: 0,
   sunflower_oil_ml: 0,
   salads_eaten: 0};
@@ -54,6 +55,7 @@ export function mapProfileRow(profileRow) {
   const source = profileRow ?? DEFAULT_PROFILE;
   const soldCount = toInt(source.sold_count, DEFAULT_PROFILE.sold_count);
   const balance = toInt(source.balance, DEFAULT_PROFILE.balance);
+  const level = toInt(source.level, DEFAULT_PROFILE.level);
   const yogurtMl = toInt(source.yogurt_ml, 0);
   const sunflowerOilMl = toInt(source.sunflower_oil_ml, 0);
   const saladsEaten = toInt(source.salads_eaten, 0);
@@ -67,7 +69,7 @@ export function mapProfileRow(profileRow) {
     passport: source.passport ?? null,
     soldCount,
     balance,
-    level: soldCount >= 50 ? 2 : 1,
+    level,
     yogurtMl,
     sunflowerOilMl,
     saladsEaten,

--- a/backend/src/routes/shop.js
+++ b/backend/src/routes/shop.js
@@ -74,7 +74,7 @@ router.post(
     await withTransaction(async (connection) => {
       const profile = await ensureProfileWithConnection(connection, req.user.id);
 
-      const level = profile.sold_count >= 50 ? 2 : 1;
+      const level = Number.parseInt(profile.level, 10) || 1;
       if (isAdvancedSeed(type) && level < 2) {
         throw new ValidationError();
       }
@@ -210,7 +210,11 @@ router.post(
 
       await connection.query('DELETE FROM inventory WHERE id = ?', [id]);
       await connection.query(
-        'UPDATE profiles SET balance = balance + ?, sold_count = sold_count + 1 WHERE user_id = ?',
+        `UPDATE profiles
+         SET balance = balance + ?,
+             sold_count = sold_count + 1,
+             level = CASE WHEN sold_count + 1 >= 50 THEN 2 ELSE 1 END
+         WHERE user_id = ?`,
         [price, req.user.id]
       );
     });


### PR DESCRIPTION
## Summary
- add a migration that adds a persisted `level` column to the `profiles` table and backfills it from existing sales
- return the stored level from the profile API instead of re-calculating it on the fly
- rely on the stored level for shop validation and update it whenever produce is sold

## Testing
- `npm test` *(fails: existing syntax error in src/logging/index.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ed5dd026ac8320b3a2c8627fd84829