### PR TITLE
feat: add responsive layout for small screens

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -17,7 +17,9 @@ body{margin:0;background:#f7f2ef;font-family:FarmHand,system-ui;}
 .tabs{display:flex;flex-wrap:wrap;gap:8px;padding:10px 20px;}
 .tab{display:flex;align-items:center;gap:8px;padding:10px 14px;border-radius:999px;background:var(--yellow);border:2px solid var(--brown);cursor:pointer;box-shadow:0 3px 0 var(--brown);}
 .tab img{width:18px;height:18px;display:block}
+.tab-label{font-weight:700;color:var(--brown);}
 .tab.active{background:#fff;}
+.main{padding:20px;}
 .card{background:rgba(255,255,255,.88);border:2px solid var(--brown);border-radius:16px;padding:16px;box-shadow:0 6px 0 var(--brown);}
 .grid{display:grid;gap:16px;}
 .grid-2{grid-template-columns:repeat(2,1fr);}
@@ -65,3 +67,20 @@ body{margin:0;background:#f7f2ef;font-family:FarmHand,system-ui;}
 .farmer-card{text-align:center;}
 .farmer-illustration{margin:12px auto;max-width:480px;border:2px solid var(--brown);border-radius:16px;overflow:hidden;box-shadow:0 4px 0 var(--brown);background:#fff;}
 .farmer-illustration img{width:100%;display:block;}
+
+@media (max-width:739px){
+  .header{flex-direction:column;align-items:stretch;text-align:center;gap:10px;padding:16px;}
+  .logo{margin:0 auto;}
+  .badge{align-self:stretch;}
+  .tabs{padding:12px 16px;gap:12px;flex-wrap:nowrap;overflow-x:auto;}
+  .tab{flex-direction:column;gap:6px;min-width:64px;}
+  .tab-label{display:none;}
+  .main{padding:16px 14px;}
+  .grid-2,.grid-3{grid-template-columns:1fr;}
+  .row{flex-direction:column;align-items:stretch;}
+  .auth-page{padding:24px 12px;}
+  .auth-panel{width:100%;}
+  .auth-controls{flex-direction:column;align-items:stretch;}
+  .auth-controls.auth-single{align-items:stretch;}
+  .shop-item{flex-direction:column;align-items:stretch;gap:12px;}
+}

--- a/frontend/src/ui/components/MainLayout.tsx
+++ b/frontend/src/ui/components/MainLayout.tsx
@@ -52,12 +52,12 @@ export function MainLayout({ onLogout, onToast }: MainLayoutProps) {
             onClick={() => setActiveTab(tab.key)}
           >
             <img src={tab.icon} alt="" />
-            {tab.label}
+            <span className="tab-label">{tab.label}</span>
           </button>
         ))}
       </nav>
 
-      <main style={{ padding: 20 }}>
+      <main className="main">
         {activeTab === 'profile' && <ProfileTab onToast={onToast} />}
         {activeTab === 'shop' && <ShopTab onToast={onToast} />}
         {activeTab === 'garden' && <GardenTab onToast={onToast} />}


### PR DESCRIPTION
## Summary
- wrap tab labels to allow responsive visibility control and give main area a reusable class
- add mobile media query rules to collapse layouts and hide tab text below 740px

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ed8e0c9e588320b836a62ea1ef359e