### PR TITLE
feat: add localization error scenarios

### DIFF
--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -5,6 +5,7 @@ import shopRouter from './shop.js';
 import inventoryRouter from './inventory.js';
 import gardenRouter from './garden.js';
 import kitchenRouter from './kitchen.js';
+import localizationRouter from './localization.js';
 import { authenticate } from '../middleware/auth.js';
 
 const router = Router();
@@ -13,6 +14,7 @@ router.use('/auth', authRouter);
 router.get('/health', (_req, res) => {
   res.json({ ok: true });
 });
+router.use('/localization', localizationRouter);
 router.use(authenticate);
 router.use('/profile', profileRouter);
 router.use('/shop', shopRouter);

--- a/backend/src/routes/localization.js
+++ b/backend/src/routes/localization.js
@@ -1,0 +1,44 @@
+import { Router } from 'express';
+
+const router = Router();
+
+const REQUIRED_FIELDS = ['login', 'password'];
+
+router.post('/2', (req, res) => {
+  const missing = REQUIRED_FIELDS.filter((field) => typeof req.body?.[field] !== 'string');
+  if (missing.length > 0) {
+    res.status(400).json({
+      error: 'Некорректное тело запроса',
+      details: `Отсутствуют поля: ${missing.join(', ')}`
+    });
+    return;
+  }
+
+  res.status(200).json({ message: 'Тело запроса корректно' });
+});
+
+router.post('/3', (req, res) => {
+  const timer = setTimeout(() => {
+    if (!res.headersSent) {
+      res.status(504).json({ error: 'Таймаут обработки запроса' });
+    }
+  }, 120000);
+
+  req.on('close', () => {
+    clearTimeout(timer);
+  });
+});
+
+router.post('/4', (_req, res) => {
+  res.json({ status: 'ok', payload: { userId: null, permissions: [] } });
+});
+
+router.post('/5', (_req, res) => {
+  res.status(500).end();
+});
+
+router.post('/6', (_req, res) => {
+  res.json({ success: true, tokens: { accessToken: 'demo-access', refreshToken: 'demo-refresh' } });
+});
+
+export default router;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -35,6 +35,22 @@ body{margin:0;background:#f7f2ef;font-family:FarmHand,system-ui;}
 .modal{width:min(480px,95vw);}
 .input{display:flex;flex-direction:column;gap:4px;}
 .input input{padding:10px;border:2px solid var(--brown);border-radius:10px;}
+.localization-page{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:40px 16px;box-sizing:border-box;}
+.localization-card{width:min(520px,95vw);display:grid;gap:16px;}
+.localization-header{display:flex;align-items:center;gap:12px;justify-content:space-between;}
+.localization-back{background:none;border:none;padding:0;color:var(--brown);cursor:pointer;font-size:14px;text-decoration:underline;}
+.localization-back:hover{text-decoration:none;}
+.localization-label{font-weight:700;color:var(--brown);}
+.localization-description{margin:0;color:#5d4037;}
+.localization-form{display:grid;gap:12px;}
+.localization-status{padding:10px 12px;border:2px dashed var(--brown);border-radius:12px;background:#fff6e5;color:#5d4037;font-weight:600;}
+.localization-hint{margin:0;color:#5d4037;font-size:14px;}
+.localization-list{list-style:none;margin:0;padding:0;display:grid;gap:8px;}
+.localization-link{width:100%;display:flex;align-items:center;gap:12px;border:none;background:#fff;border:2px solid var(--brown);border-radius:12px;padding:10px 14px;text-align:left;cursor:pointer;box-shadow:0 4px 0 var(--brown);}
+.localization-link:hover{background:var(--yellow);}
+.localization-id{display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border-radius:50%;background:var(--yellow);font-weight:700;color:var(--brown);}
+.localization-text{font-weight:700;color:var(--brown);}
+.localization-actions{display:flex;justify-content:flex-end;}
 .err{color:var(--red);font-weight:700;}
 .slot{min-height:140px;background:#e6ffb0;border:2px dashed var(--brown);border-radius:12px;display:grid;place-items:center;}
 .shop-item{display:flex;justify-content:space-between;align-items:center;border:2px dashed var(--brown);border-radius:12px;padding:8px 12px;background:#fff;}

--- a/frontend/src/ui/components/LocalizationPage.tsx
+++ b/frontend/src/ui/components/LocalizationPage.tsx
@@ -1,0 +1,294 @@
+import React from 'react';
+
+interface LocalizationPageProps {
+  path: string;
+  onNavigate: (path: string, replace?: boolean) => void;
+}
+
+type ScenarioId = '1' | '2' | '3' | '4' | '5' | '6';
+
+interface ScenarioMeta {
+  title: string;
+  description: string;
+}
+
+const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? '/api';
+
+const SCENARIO_META: Record<ScenarioId, ScenarioMeta> = {
+  '1': {
+    title: 'Ошибка в консоли',
+    description: 'Запрос не уходит, а в консоли появляется сообщение об ошибке.'
+  },
+  '2': {
+    title: 'Некорректное тело запроса',
+    description: 'Запрос отправляется, но сервер возвращает 400 из-за неверного тела.'
+  },
+  '3': {
+    title: 'Нет ответа от сервера',
+    description: 'Запрос уходит корректно, но сервер не возвращает ответ в ожидаемое время.'
+  },
+  '4': {
+    title: 'Неправильные данные в ответе',
+    description: 'Запрос успешен, но сервер возвращает неожидаемую структуру данных.'
+  },
+  '5': {
+    title: 'Внутренняя ошибка сервера без уведомления',
+    description: 'Запрос завершился с 500 ошибкой, но пользователь не получил уведомления.'
+  },
+  '6': {
+    title: 'Ответ получен, но не показан',
+    description: 'Запрос успешен, но результат не отображается пользователю.'
+  }
+};
+
+export default function LocalizationPage({ path, onNavigate }: LocalizationPageProps) {
+  const segment = React.useMemo(() => {
+    if (path === '/localization') return null;
+    const parts = path.split('/').filter(Boolean);
+    return parts.length >= 2 ? (parts[1] as ScenarioId) : null;
+  }, [path]);
+
+  if (!path.startsWith('/localization')) {
+    return null;
+  }
+
+  if (segment && !SCENARIO_META[segment]) {
+    return (
+      <div className="localization-page">
+        <div className="card localization-card">
+          <h2>Сценарий не найден</h2>
+          <p>Перейдите к списку сценариев и выберите нужный пример.</p>
+          <div className="localization-actions">
+            <button className="btn" onClick={() => onNavigate('/localization', true)}>
+              К списку сценариев
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!segment) {
+    return (
+      <div className="localization-page">
+        <div className="card localization-card">
+          <h2>Локализация ошибок</h2>
+          <p>
+            Выберите сценарий, чтобы показать учащимся, как диагностировать различные проблемы при авторизации.
+          </p>
+          <ul className="localization-list">
+            {(Object.keys(SCENARIO_META) as ScenarioId[]).map((id) => (
+              <li key={id}>
+                <button
+                  className="localization-link"
+                  onClick={() => onNavigate(`/localization/${id}`)}
+                >
+                  <span className="localization-id">{id}</span>
+                  <span className="localization-text">{SCENARIO_META[id].title}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+
+  return <LocalizationScenario id={segment} onNavigate={onNavigate} />;
+}
+
+interface LocalizationScenarioProps {
+  id: ScenarioId;
+  onNavigate: (path: string, replace?: boolean) => void;
+}
+
+function LocalizationScenario({ id, onNavigate }: LocalizationScenarioProps) {
+  const [login, setLogin] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [status, setStatus] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const description = SCENARIO_META[id].description;
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setStatus(null);
+
+    if (!login || !password) {
+      setStatus('Заполните логин и пароль для запуска сценария.');
+      return;
+    }
+
+    const payload = { login, password };
+
+    switch (id) {
+      case '1': {
+        console.error('Демонстрационный сбой: запрос не отправлен из-за ошибки в клиентском коде.');
+        setStatus('Запрос не был отправлен. Подробности смотрите в консоли.');
+        break;
+      }
+      case '2': {
+        try {
+          setLoading(true);
+          const response = await fetch(`${API_BASE}/localization/2`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username: login, secret: password })
+          });
+          const data = await response.json().catch(() => null);
+          if (!response.ok) {
+            setStatus(
+              data?.details
+                ? `Сервер отклонил запрос: ${data.details}`
+                : 'Сервер вернул ошибку из-за неверного тела запроса.'
+            );
+          } else {
+            setStatus('Сервер принял запрос, хотя тело было составлено неверно.');
+          }
+        } catch (error) {
+          console.error('Ошибка при отправке запроса', error);
+          setStatus('Не удалось отправить запрос.');
+        } finally {
+          setLoading(false);
+        }
+        break;
+      }
+      case '3': {
+        setLoading(true);
+        const controller = new AbortController();
+        const timeout = window.setTimeout(() => {
+          controller.abort();
+        }, 7000);
+        try {
+          await fetch(`${API_BASE}/localization/3`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+            signal: controller.signal
+          });
+        } catch (error) {
+          if ((error as DOMException).name === 'AbortError') {
+            setStatus('Ответ не был получен: сервер не обработал запрос.');
+          } else {
+            setStatus('Произошла сетевая ошибка при ожидании ответа.');
+          }
+        } finally {
+          window.clearTimeout(timeout);
+          setLoading(false);
+        }
+        break;
+      }
+      case '4': {
+        try {
+          setLoading(true);
+          const response = await fetch(`${API_BASE}/localization/4`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+          });
+          const data = await response.json();
+          if (!('success' in data)) {
+            setStatus('Получены неожиданные данные: проверьте вкладку Network.');
+          } else {
+            setStatus('Ответ соответствует ожиданиям.');
+          }
+        } catch (error) {
+          console.error('Ошибка при обработке ответа', error);
+          setStatus('Не удалось обработать ответ сервера.');
+        } finally {
+          setLoading(false);
+        }
+        break;
+      }
+      case '5': {
+        try {
+          setLoading(true);
+          const response = await fetch(`${API_BASE}/localization/5`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+          });
+          if (!response.ok) {
+            console.error('Сервер вернул 500 без тела ответа.');
+          }
+        } catch (error) {
+          console.error('Ошибка при выполнении запроса', error);
+        } finally {
+          setLoading(false);
+        }
+        break;
+      }
+      case '6': {
+        try {
+          setLoading(true);
+          const response = await fetch(`${API_BASE}/localization/6`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+          });
+          if (response.ok) {
+            await response.json();
+            console.log('Ответ успешно получен, но не показан пользователю.');
+          } else {
+            setStatus('Сервер вернул ошибку при обработке запроса.');
+          }
+        } catch (error) {
+          console.error('Ошибка при обработке успешного ответа', error);
+          setStatus('Не удалось обработать ответ сервера.');
+        } finally {
+          setLoading(false);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className="localization-page">
+      <div className="card localization-card">
+        <div className="localization-header">
+          <button className="localization-back" onClick={() => onNavigate('/localization', true)}>
+            ← Все сценарии
+          </button>
+          <span className="localization-label">Сценарий {id}</span>
+        </div>
+        <h2>{SCENARIO_META[id].title}</h2>
+        <p className="localization-description">{description}</p>
+
+        <form className="localization-form" onSubmit={submit}>
+          <label className="input">
+            <span>Логин</span>
+            <input
+              type="text"
+              value={login}
+              onChange={(event) => setLogin(event.target.value)}
+              placeholder="demo@login"
+            />
+          </label>
+          <label className="input">
+            <span>Пароль</span>
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              placeholder="••••••"
+            />
+          </label>
+          <button className="btn" type="submit" disabled={loading}>
+            {loading ? 'Выполняется...' : 'Вход'}
+          </button>
+        </form>
+
+        {status ? <div className="localization-status">{status}</div> : null}
+
+        {id === '5' ? (
+          <p className="localization-hint">Обратите внимание, что визуального уведомления об ошибке нет.</p>
+        ) : null}
+        {id === '6' ? (
+          <p className="localization-hint">Ответ получен. Откройте консоль, чтобы увидеть сообщение от разработчика.</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add backend routes that simulate distinct localization login scenarios
- expose a dedicated localization training flow on the frontend with scenario-specific behaviours
- update routing and styling to support the new localization pages without disrupting existing auth flow

## Testing
- npm --prefix frontend run build
- npm --prefix backend test *(fails: SyntaxError in src/logging/index.js unrelated to the new changes)*

------
https://chatgpt.com/codex/tasks/task_e_68f266b1b7b08320aba3f656fab340e3