### PR TITLE
Adjust localization scenarios to demonstrate pass field handling

### DIFF
--- a/backend/src/routes/localization.js
+++ b/backend/src/routes/localization.js
@@ -8,13 +8,24 @@ router.post('/1', (_req, res) => {
   });
 });
 
-router.post('/2', (_req, res) => {
-  setTimeout(() => {
-    res.status(504).json({
-      error: 'Gateway Timeout',
-      message: 'Сервер не успел обработать запрос за отведённое время'
+router.post('/2', (req, res) => {
+  const { login, password, pass } = req.body ?? {};
+
+  if (typeof login === 'string' && typeof password === 'string') {
+    return res.json({ success: true });
+  }
+
+  if (typeof login === 'string' && typeof pass === 'string' && typeof password === 'undefined') {
+    return res.status(400).json({
+      error: 'Некорректное тело запроса',
+      message: 'Ожидалось поле password, но получено pass.'
     });
-  }, 2500);
+  }
+
+  return res.status(400).json({
+    error: 'Некорректные данные',
+    message: 'Поля login и password обязательны для заполнения'
+  });
 });
 
 // сценарий 3 — сервер возвращает 504 после ожидания


### PR DESCRIPTION
## Summary
- update the localization scenario 2 endpoint to flag pass instead of password in the request
- sync the frontend scenario descriptions and messaging with the new pass/password behavior
- remove the predefined masks from the login and password inputs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f2806dfe80832097b74354bda54467