### PR TITLE
Reset localization scenario status on navigation and update scenario 4 response

### DIFF
--- a/backend/src/routes/localization.js
+++ b/backend/src/routes/localization.js
@@ -38,12 +38,9 @@ router.post('/3', (_req, res) => {
   }, 8000);
 });
 
-// сценарий 4 — возврат логина и пароля
+// сценарий 4 — успешный ответ без ожидаемых полей
 router.post('/4', (req, res) => {
-  res.json({
-    login: req.body?.login ?? null,
-    pass: req.body?.password ?? null
-  });
+  res.json({ success: true });
 });
 
 router.post('/5', (_req, res) => {

--- a/frontend/src/ui/components/LocalizationPage.tsx
+++ b/frontend/src/ui/components/LocalizationPage.tsx
@@ -116,6 +116,11 @@ function LocalizationScenario({ id, onNavigate }: LocalizationScenarioProps) {
   const prevScenario = currentIndex > 0 ? SCENARIO_ORDER[currentIndex - 1] : null;
   const nextScenario = currentIndex < SCENARIO_ORDER.length - 1 ? SCENARIO_ORDER[currentIndex + 1] : null;
 
+  React.useEffect(() => {
+    setStatus(null);
+    setLoading(false);
+  }, [id]);
+
   const submit = async (event: React.FormEvent) => {
     event.preventDefault();
     setStatus(null);
@@ -198,9 +203,9 @@ function LocalizationScenario({ id, onNavigate }: LocalizationScenarioProps) {
           });
           const data = await response.json();
           if (data && typeof data === 'object') {
-            if ('login' in data && 'pass' in data && !('password' in data)) {
-              setStatus('Сервер вернул поле pass вместо password.');
-              console.error('Некорректная структура ответа: получены поля login и pass.');
+            if (data.success === true) {
+              setStatus('Сервер вернул success: true вместо ожидаемых полей login и password.');
+              console.error('Некорректная структура ответа: отсутствуют поля login и password.');
             } else if ('login' in data && 'password' in data) {
               setStatus('Ответ соответствует ожиданиям: получены login и password.');
             } else {


### PR DESCRIPTION
## Summary
- clear the localization scenario status when navigating between scenarios so stale errors disappear
- update scenario 4 handling on the frontend and backend to return a simple success flag without the expected fields

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2832638408320b2534ffbf7b3e64c