### PR TITLE
Handle rotten vegetables in inventory

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -388,6 +388,22 @@ paths:
                   vegWashed:
                     type: array
                     items: { $ref: '#/components/schemas/InventoryItem' }
+                  vegRotten:
+                    type: array
+                    items: { $ref: '#/components/schemas/InventoryItem' }
+  /inventory/{id}:
+    delete:
+      security: [{ bearerAuth: [] }]
+      summary: Выкинуть протухший овощ
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
   /inventory/wash/{id}:
     patch:
       security: [{ bearerAuth: [] }]

--- a/backend/src/routes/inventory.js
+++ b/backend/src/routes/inventory.js
@@ -23,11 +23,38 @@ router.get(
       [req.user.id]
     );
 
-    const seeds = rows.filter((row) => row.kind === 'seed');
-    const vegRaw = rows.filter((row) => row.kind === 'veg_raw');
-    const vegWashed = rows.filter((row) => row.kind === 'veg_washed');
+    const now = Date.now();
+    const ROTTEN_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
 
-    const response = { seeds, vegRaw, vegWashed };
+    const seeds = [];
+    const vegRaw = [];
+    const vegWashed = [];
+    const vegRotten = [];
+
+    for (const row of rows) {
+      if (row.kind === 'seed') {
+        seeds.push(row);
+        continue;
+      }
+
+      if (row.kind === 'veg_washed') {
+        vegWashed.push(row);
+        continue;
+      }
+
+      if (row.kind === 'veg_raw') {
+        const createdAtMs = new Date(row.created_at).getTime();
+        const isRotten = Number.isFinite(createdAtMs) && now - createdAtMs >= ROTTEN_THRESHOLD_MS;
+
+        if (isRotten) {
+          vegRotten.push({ ...row, status: 'rotten' });
+        } else {
+          vegRaw.push(row);
+        }
+      }
+    }
+
+    const response = { seeds, vegRaw, vegWashed, vegRotten };
     res.json(response);
     logApiResponse('Inventory requested', {
       event: 'inventory.list',
@@ -37,6 +64,7 @@ router.get(
       seeds: seeds.length,
       vegRaw: vegRaw.length,
       vegWashed: vegWashed.length,
+      vegRotten: vegRotten.length,
       response
     });
   })
@@ -83,6 +111,62 @@ router.patch(
       event: 'inventory.wash',
       method: 'PATCH',
       path: `/api/inventory/wash/${id}`,
+      userId: req.user.id,
+      inventoryId: id,
+      response
+    });
+  })
+);
+
+router.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const { id: paramId } = req.params;
+    logApiRequest('Inventory item deleted', {
+      event: 'inventory.delete',
+      method: 'DELETE',
+      path: `/api/inventory/${paramId ?? ''}`,
+      userId: req.user.id,
+      inventoryId: paramId ?? null
+    });
+
+    if (paramId === undefined || paramId === null || paramId === '') {
+      throw new RequiredFieldError();
+    }
+
+    const id = Number(paramId);
+    if (!Number.isInteger(id) || id <= 0) {
+      throw new ValidationError();
+    }
+
+    const ROTTEN_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
+    const now = Date.now();
+
+    await withTransaction(async (connection) => {
+      const [[item]] = await connection.query(
+        'SELECT * FROM inventory WHERE id = ? AND user_id = ? FOR UPDATE',
+        [id, req.user.id]
+      );
+      if (!item || item.kind !== 'veg_raw') {
+        throw new ValidationError();
+      }
+
+      const createdAtMs = new Date(item.created_at).getTime();
+      const isRotten = Number.isFinite(createdAtMs) && now - createdAtMs >= ROTTEN_THRESHOLD_MS;
+
+      if (!isRotten) {
+        throw new ValidationError();
+      }
+
+      await connection.query('DELETE FROM inventory WHERE id = ?', [id]);
+    });
+
+    const response = { ok: true };
+    res.json(response);
+    logApiResponse('Inventory item deleted', {
+      event: 'inventory.delete',
+      method: 'DELETE',
+      path: `/api/inventory/${id}`,
       userId: req.user.id,
       inventoryId: id,
       response

--- a/frontend/src/ui/components/tabs/InventoryTab.tsx
+++ b/frontend/src/ui/components/tabs/InventoryTab.tsx
@@ -15,6 +15,7 @@ interface InventoryResponse {
   seeds: InventoryItem[];
   vegRaw: InventoryItem[];
   vegWashed: InventoryItem[];
+  vegRotten: InventoryItem[];
 }
 
 interface InventoryTabProps {
@@ -22,7 +23,12 @@ interface InventoryTabProps {
 }
 
 export function InventoryTab({ onToast }: InventoryTabProps) {
-  const [inventory, setInventory] = React.useState<InventoryResponse>({ seeds: [], vegRaw: [], vegWashed: [] });
+  const [inventory, setInventory] = React.useState<InventoryResponse>({
+    seeds: [],
+    vegRaw: [],
+    vegWashed: [],
+    vegRotten: []
+  });
 
   const loadInventory = React.useCallback(async () => {
     const { data } = await api.get<InventoryResponse>('/inventory');
@@ -36,6 +42,12 @@ export function InventoryTab({ onToast }: InventoryTabProps) {
   const wash = async (inventoryId: number) => {
     await api.patch(`/inventory/wash/${inventoryId}`);
     onToast('Вымыто');
+    loadInventory();
+  };
+
+  const discard = async (inventoryId: number) => {
+    await api.delete(`/inventory/${inventoryId}`);
+    onToast('Выброшено');
     loadInventory();
   };
 
@@ -94,6 +106,27 @@ export function InventoryTab({ onToast }: InventoryTabProps) {
                   <div>{SEED_NAMES[item.type]}</div>
                 </div>
                 <div className="badge">{item.status}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="card">
+        <h3>Протухшие овощи</h3>
+        {inventory.vegRotten.length === 0 ? (
+          <div>Пусто</div>
+        ) : (
+          <div className="grid">
+            {inventory.vegRotten.map((item) => (
+              <div key={item.id} className="shop-item">
+                <div className="shop-left">
+                  <img src={SEED_ICONS[item.type]} alt="" />
+                  <div>{SEED_NAMES[item.type]}</div>
+                </div>
+                <button className="btn danger" onClick={() => discard(item.id)}>
+                  Выкинуть
+                </button>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- categorize unwashed vegetables older than 24 hours as rotten in the inventory API response
- allow deleting rotten vegetables and document the new API contract in OpenAPI
- display rotten vegetables in the inventory tab with a discard action on the frontend

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f41827a4348320a8b41ec9ab6a7771