### PR TITLE
Persist rotten vegetables and split salad flow

### DIFF
--- a/backend/migrations/005_add_inventory_rotten_column.sql
+++ b/backend/migrations/005_add_inventory_rotten_column.sql
@@ -1,0 +1,11 @@
+SET @add_rotten_sql := IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'inventory'
+      AND COLUMN_NAME = 'is_rotten') = 0,
+  'ALTER TABLE `inventory` ADD COLUMN `is_rotten` TINYINT(1) NOT NULL DEFAULT 0;',
+  'SELECT 1;'
+);
+PREPARE add_rotten_stmt FROM @add_rotten_sql;
+EXECUTE add_rotten_stmt;
+DEALLOCATE PREPARE add_rotten_stmt;

--- a/backend/migrations/006_add_prepared_salads_column.sql
+++ b/backend/migrations/006_add_prepared_salads_column.sql
@@ -1,0 +1,11 @@
+SET @add_prepared_sql := IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'profiles'
+      AND COLUMN_NAME = 'prepared_salads') = 0,
+  'ALTER TABLE `profiles` ADD COLUMN `prepared_salads` INT NOT NULL DEFAULT 0;',
+  'SELECT 1;'
+);
+PREPARE add_prepared_stmt FROM @add_prepared_sql;
+EXECUTE add_prepared_stmt;
+DEALLOCATE PREPARE add_prepared_stmt;

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -166,6 +166,7 @@ components:
         yogurtMl: { type: integer, minimum: 0 }
         sunflowerOilMl: { type: integer, minimum: 0 }
         saladsEaten: { type: integer, minimum: 0 }
+        preparedSalads: { type: integer, minimum: 0 }
         isFatFarmer: { type: boolean }
     InventoryItem:
       type: object
@@ -175,6 +176,7 @@ components:
         type: { type: string, enum: [radish, carrot, cabbage, mango, potato, eggplant] }
         status: { type: string }
         createdAt: { type: string, format: date-time }
+        isRotten: { type: boolean }
     Plot:
       type: object
       properties:
@@ -307,16 +309,6 @@ paths:
       responses:
         '200':
           description: OK
-  /shop/prices:
-    get:
-      security: [{ bearerAuth: [] }]
-      summary: Получить цены магазина
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/ShopPrices' }
   /shop/sell:
     post:
       security: [{ bearerAuth: [] }]
@@ -367,6 +359,16 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/KitchenState' }
+  /kitchen/salads/eat:
+    post:
+      security: [{ bearerAuth: [] }]
+      summary: Съесть приготовленный салат
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/KitchenState' }
   /inventory:
     get:
       security: [{ bearerAuth: [] }]
@@ -388,6 +390,22 @@ paths:
                   vegWashed:
                     type: array
                     items: { $ref: '#/components/schemas/InventoryItem' }
+                  vegRotten:
+                    type: array
+                    items: { $ref: '#/components/schemas/InventoryItem' }
+  /inventory/{id}:
+    delete:
+      security: [{ bearerAuth: [] }]
+      summary: Выкинуть протухший овощ
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
   /inventory/wash/{id}:
     patch:
       security: [{ bearerAuth: [] }]

--- a/frontend/src/ui/components/tabs/InventoryTab.tsx
+++ b/frontend/src/ui/components/tabs/InventoryTab.tsx
@@ -9,12 +9,14 @@ interface InventoryItem {
   type: SeedType;
   status: string;
   created_at: string;
+  is_rotten?: boolean;
 }
 
 interface InventoryResponse {
   seeds: InventoryItem[];
   vegRaw: InventoryItem[];
   vegWashed: InventoryItem[];
+  vegRotten: InventoryItem[];
 }
 
 interface InventoryTabProps {
@@ -22,7 +24,12 @@ interface InventoryTabProps {
 }
 
 export function InventoryTab({ onToast }: InventoryTabProps) {
-  const [inventory, setInventory] = React.useState<InventoryResponse>({ seeds: [], vegRaw: [], vegWashed: [] });
+  const [inventory, setInventory] = React.useState<InventoryResponse>({
+    seeds: [],
+    vegRaw: [],
+    vegWashed: [],
+    vegRotten: []
+  });
 
   const loadInventory = React.useCallback(async () => {
     const { data } = await api.get<InventoryResponse>('/inventory');
@@ -36,6 +43,12 @@ export function InventoryTab({ onToast }: InventoryTabProps) {
   const wash = async (inventoryId: number) => {
     await api.patch(`/inventory/wash/${inventoryId}`);
     onToast('Вымыто');
+    loadInventory();
+  };
+
+  const discard = async (inventoryId: number) => {
+    await api.delete(`/inventory/${inventoryId}`);
+    onToast('Выброшено');
     loadInventory();
   };
 
@@ -94,6 +107,27 @@ export function InventoryTab({ onToast }: InventoryTabProps) {
                   <div>{SEED_NAMES[item.type]}</div>
                 </div>
                 <div className="badge">{item.status}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="card">
+        <h3>Протухшие овощи</h3>
+        {inventory.vegRotten.length === 0 ? (
+          <div>Пусто</div>
+        ) : (
+          <div className="grid">
+            {inventory.vegRotten.map((item) => (
+              <div key={item.id} className="shop-item">
+                <div className="shop-left">
+                  <img src={SEED_ICONS[item.type]} alt="" />
+                  <div>{SEED_NAMES[item.type]}</div>
+                </div>
+                <button className="btn danger" onClick={() => discard(item.id)}>
+                  Выкинуть
+                </button>
               </div>
             ))}
           </div>

--- a/frontend/src/ui/components/tabs/KitchenTab.tsx
+++ b/frontend/src/ui/components/tabs/KitchenTab.tsx
@@ -11,6 +11,7 @@ interface KitchenState {
   sunflowerOilMl: number;
   saladsEaten: number;
   isFatFarmer: boolean;
+  preparedSalads: number;
 }
 
 interface KitchenTabProps {
@@ -166,15 +167,23 @@ export function KitchenTab({ onToast }: KitchenTabProps) {
     }
 
     try {
-      const { data } = await api.post<KitchenState>('/kitchen/salads', {
+      const { data: preparedState } = await api.post<KitchenState>('/kitchen/salads', {
         recipe: recipeKey,
         ingredients: selection
       });
-      setState(data);
+      setState(preparedState);
 
-       if (recipeKey === 'fruit') setFruitMessage(null);
-       else setVegetableMessage(null);
-       onToast('Салат готов!');
+      try {
+        const { data: eatenState } = await api.post<KitchenState>('/kitchen/salads/eat');
+        setState(eatenState);
+        if (recipeKey === 'fruit') setFruitMessage(null);
+        else setVegetableMessage(null);
+        onToast('Салат приготовлен и съеден!');
+      } catch (eatError) {
+        console.error('Failed to eat salad', eatError);
+        onToast('Салат приготовлен, но не съеден');
+        await load();
+      }
     } catch (error) {
       console.error('Failed to prepare salad', error);
       onToast('Не удалось приготовить салат');


### PR DESCRIPTION
## Summary
- add migrations and backend logic to persist rotten vegetables and expose the new flag in the API response
- remove the /shop/prices GET entry from OpenAPI and document the new salad preparation/eating flow
- split salad preparation and eating into separate endpoints with prepared_salads tracking and update the frontend to call the new APIs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f41827a4348320a8b41ec9ab6a7771