### PR TITLE
Add conflict response for washed vegetables and expose profile id

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3,6 +3,9 @@ openapi: 3.0.3
 info:
   title: Artem Ferm API
   version: 1.0.0
+externalDocs:
+  description: Импортировать коллекцию в Postman
+  url: /api/docs/openapi.json
 servers:
   - url: /api
 components:
@@ -54,6 +57,9 @@ components:
     Profile:
       type: object
       properties:
+        id:
+          type: integer
+          readOnly: true
         isCoolFarmer: { type: boolean }
         firstName: { type: string, nullable: true }
         lastName: { type: string, nullable: true }

--- a/backend/src/routes/inventory.js
+++ b/backend/src/routes/inventory.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { asyncHandler } from '../utils/async-handler.js';
 import { getPool, withTransaction } from '../db/pool.js';
-import { RequiredFieldError, ValidationError } from '../utils/errors.js';
+import { ConflictError, RequiredFieldError, ValidationError } from '../utils/errors.js';
 import { logApiRequest, logApiResponse } from '../logging/index.js';
 
 const router = Router();
@@ -130,7 +130,15 @@ router.patch(
       );
 
       // Мы можем мыть только свежий сырой овощ
-      if (!item || item.kind !== 'veg_raw' || item.is_rotten) {
+      if (!item) {
+        throw new ValidationError();
+      }
+
+      if (item.kind === 'veg_washed') {
+        throw new ConflictError('Данный овощ уже чистый');
+      }
+
+      if (item.kind !== 'veg_raw' || item.is_rotten) {
         throw new ValidationError();
       }
 

--- a/backend/src/utils/errors.js
+++ b/backend/src/utils/errors.js
@@ -30,3 +30,9 @@ export class NotFoundError extends HttpError {
     super(404, message);
   }
 }
+
+export class ConflictError extends HttpError {
+  constructor(message = 'Конфликт') {
+    super(409, message);
+  }
+}


### PR DESCRIPTION
## Summary
- return HTTP 409 when attempting to wash an already clean vegetable
- include the user identifier in profile API responses and document it in OpenAPI
- add an external docs link in Swagger to download the OpenAPI spec for Postman import

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690773e34c1083208f307897eb578b72