### PR TITLE
Fix disappearing Swagger download link

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -33,14 +33,19 @@ function buildFallbackSpec() {
 }
 
 function setupSwagger(app) {
+  const swaggerDocument = loadOpenApi() ?? buildFallbackSpec();
+  const swaggerDocumentUrl = '/api/docs/openapi.json';
+
   const swaggerUiOptions = {
     explorer: true,
     swaggerOptions: {
+      url: swaggerDocumentUrl,
+      spec: swaggerDocument,
       persistAuthorization: true
     }
   };
 
-  app.get('/api/docs/openapi.json', (_req, res) => {
+  app.get(swaggerDocumentUrl, (_req, res) => {
     const spec = loadOpenApi();
     if (spec) {
       res.json(spec);
@@ -49,7 +54,6 @@ function setupSwagger(app) {
     }
   });
 
-  const swaggerDocument = loadOpenApi() ?? buildFallbackSpec();
   app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument, swaggerUiOptions));
 }
 


### PR DESCRIPTION
## Summary
- configure Swagger UI to serve the specification via the JSON endpoint
- keep the download link visible by providing both the spec object and its URL

## Testing
- npm test -- --test-name-pattern loadOpenApi

------
https://chatgpt.com/codex/tasks/task_e_6907b2422fbc8320be1b793305391a8e