### PR TITLE
Make profile level migration idempotent

### DIFF
--- a/backend/migrations/004_add_level_column.sql
+++ b/backend/migrations/004_add_level_column.sql
@@ -1,5 +1,14 @@
-ALTER TABLE profiles
-  ADD COLUMN level INT NOT NULL DEFAULT 1 AFTER sold_count;
+SET @add_level_sql := IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'profiles'
+      AND COLUMN_NAME = 'level') = 0,
+  'ALTER TABLE `profiles` ADD COLUMN `level` INT NOT NULL DEFAULT 1 AFTER `sold_count`;',
+  'SELECT 1;'
+);
+PREPARE add_level_stmt FROM @add_level_sql;
+EXECUTE add_level_stmt;
+DEALLOCATE PREPARE add_level_stmt;
 
 UPDATE profiles
 SET level = CASE WHEN sold_count >= 50 THEN 2 ELSE 1 END;


### PR DESCRIPTION
## Summary
- update the `profiles.level` migration to only add the column when it is missing
- keep the existing data backfill so rerunning migrations no longer fails

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cad264e148320b857db619a8b794a)