### PR TITLE
Add Kafka logging for plant message production and consumption

### DIFF
--- a/backend/src/routes/garden.js
+++ b/backend/src/routes/garden.js
@@ -6,7 +6,7 @@ import config from '../config/index.js';
 import { ConflictError, RequiredFieldError, ValidationError, ServiceUnavailableError } from '../utils/errors.js';
 import { hasMatured } from '../utils/garden.js';
 import { ensurePlotsInitialized } from '../services/user-setup.js';
-import { logApiRequest, logApiResponse } from '../logging/index.js';
+import { logApiRequest, logApiResponse, logInfo } from '../logging/index.js';
 import { requireAdmin } from '../middleware/authorize.js';
 import { getProducer, kafkaAvailable } from '../utils/message-broker.js';
 
@@ -103,6 +103,15 @@ router.post(
           value: JSON.stringify(messagePayload)
         }
       ]
+    });
+
+    logInfo('Задача посадки отправлена в Kafka', {
+      event: 'garden.plant.produced',
+      topic: config.kafka.plantTopic,
+      requestId,
+      userId: req.user.id,
+      slot: slotNumber,
+      inventoryId: inventoryNumber
     });
 
     const response = { accepted: true, requestId };

--- a/backend/src/workers/plant-consumer.js
+++ b/backend/src/workers/plant-consumer.js
@@ -45,6 +45,17 @@ async function handlePlantingMessage(context) {
     return;
   }
 
+  logInfo('Сообщение посадки получено consumer', {
+    event: 'garden.plant.received',
+    topic,
+    partition,
+    offset: message.offset,
+    requestId: payload.requestId,
+    userId: payload.userId,
+    slot: payload.slot,
+    inventoryId: payload.inventoryId
+  });
+
   try {
     const result = await plantSeed({
       userId: payload.userId,


### PR DESCRIPTION
## Summary
- log Kafka plant message production with request and user context for OpenSearch visibility
- log consumer receipt of plant messages before processing for traceability

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69238cb6761883209fbe8a6342442fb9)