### PR TITLE
Tune Vector batching for faster OpenSearch logging

### DIFF
--- a/vector/vector.toml
+++ b/vector/vector.toml
@@ -32,3 +32,5 @@ endpoint = "http://opensearch:9200"
 index    = "ferm-logs"
 mode     = "bulk"
 compression = "none"
+batch.max_events = 200
+batch.timeout_secs = 5


### PR DESCRIPTION
## Summary
- configure Vector's OpenSearch sink with smaller batches to flush logs quickly
- ensure log batches are sent at most every few seconds to meet the 10-second target

## Testing
- not run (config change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ccf854f4832081bd81ab292fdfca)