### PR TITLE
Add integration tag to logs

### DIFF
--- a/backend/src/db/pool.js
+++ b/backend/src/db/pool.js
@@ -100,7 +100,8 @@ function buildLogPayload(sql, params) {
   const operation = detectOperation(sql);
   const payload = {
     event: 'db.query',
-    sql: normalizeSql(sql)
+    sql: normalizeSql(sql),
+    skipIntegrationName: true
   };
 
   const sanitizedParams = sanitizeParams(params);

--- a/backend/src/routes/garden.js
+++ b/backend/src/routes/garden.js
@@ -61,6 +61,7 @@ router.post(
       event: 'garden.plant',
       method: 'POST',
       path: '/api/garden/plant',
+      IntegrationName: 'Clients',
       userId: req.user.id,
       slot: slot ?? null,
       inventoryId: inventoryId ?? null
@@ -122,6 +123,7 @@ router.post(
       method: 'POST',
       path: '/api/garden/plant',
       status: res.statusCode,
+      IntegrationName: 'Clients',
       userId: req.user.id,
       slot: slotNumber,
       inventoryId: inventoryNumber,

--- a/backend/src/routes/localization.js
+++ b/backend/src/routes/localization.js
@@ -3,8 +3,7 @@ const router = express.Router();
 
 router.post('/1', (_req, res) => {
   res.status(400).json({
-    error: 'Некорректные данные',
-    message: 'Поля login и password обязательны для заполнения'
+    error: 'Некорректные данные'
   });
 });
 
@@ -17,14 +16,12 @@ router.post('/2', (req, res) => {
 
   if (typeof login === 'string' && typeof pass === 'string' && typeof password === 'undefined') {
     return res.status(400).json({
-      error: 'Некорректное тело запроса',
-      message: 'Ожидалось поле password, но получено pass.'
+      error: 'Некорректное тело запроса'
     });
   }
 
   return res.status(400).json({
-    error: 'Некорректные данные',
-    message: 'Поля login и password обязательны для заполнения'
+    error: 'Некорректные данные'
   });
 });
 
@@ -32,8 +29,7 @@ router.post('/2', (req, res) => {
 router.post('/3', (_req, res) => {
   setTimeout(() => {
     res.status(504).json({
-      error: 'Gateway Timeout',
-      message: 'Сервер не успел обработать запрос и вернул 504 ошибку'
+      error: 'Gateway Timeout'
     });
   }, 8000);
 });


### PR DESCRIPTION
## Summary
- add automatic IntegrationName tagging to most logs with database logs excluded
- mark garden plant request logs with IntegrationName Clients
- remove helper messages from localization training responses

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f9208b808320b430bf0d53dcfad6)