### PR TITLE
Add email notifications for ripe vegetables

### DIFF
--- a/backend/migrations/008_add_plot_notification_flag.sql
+++ b/backend/migrations/008_add_plot_notification_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE plots
+  ADD COLUMN matured_notified TINYINT(1) NOT NULL DEFAULT 0 AFTER harvested;

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "jsonwebtoken": "9.0.2",
     "kafkajs": "2.2.4",
     "mysql2": "3.11.0",
+    "nodemailer": "6.9.14",
     "swagger-ui-express": "5.0.1",
     "yaml": "2.5.0"
   }

--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -100,6 +100,18 @@ const config = {
     clientId: getString(process.env.KAFKA_CLIENT_ID, 'ferm-backend'),
     consumerGroup: getString(process.env.KAFKA_CONSUMER_GROUP, 'ferm-plant-consumers'),
     plantTopic: getString(process.env.KAFKA_PLANT_TOPIC, 'ferm.garden.plant')
+  },
+  email: {
+    enabled: toBool(process.env.EMAIL_ENABLED, false),
+    host: getString(process.env.EMAIL_HOST, 'smtp'),
+    port: toInt(process.env.EMAIL_PORT, 1025),
+    secure: toBool(process.env.EMAIL_SECURE, false),
+    user: getString(process.env.EMAIL_USER),
+    password: getString(process.env.EMAIL_PASSWORD),
+    from: getString(process.env.EMAIL_FROM, 'no-reply@ferma.local')
+  },
+  scheduler: {
+    maturityCheckIntervalMs: toInt(process.env.MATURITY_CHECK_INTERVAL_MS, 60000)
   }
 };
 

--- a/backend/src/routes/garden.js
+++ b/backend/src/routes/garden.js
@@ -165,7 +165,9 @@ router.post(
       }
 
       await connection.query(
-        'UPDATE plots SET harvested = 1, type = NULL, planted_at = NULL WHERE user_id = ? AND slot = ?',
+        `UPDATE plots
+         SET harvested = 1, type = NULL, planted_at = NULL, matured_notified = 0
+         WHERE user_id = ? AND slot = ?`,
         [req.user.id, slotNumber]
       );
       await connection.query(
@@ -223,7 +225,9 @@ router.delete(
       }
 
       await connection.query(
-        'UPDATE plots SET harvested = 0, type = NULL, planted_at = NULL WHERE user_id = ? AND slot = ?',
+        `UPDATE plots
+         SET harvested = 0, type = NULL, planted_at = NULL, matured_notified = 0
+         WHERE user_id = ? AND slot = ?`,
         [req.user.id, slotNumber]
       );
 

--- a/backend/src/services/garden.js
+++ b/backend/src/services/garden.js
@@ -38,7 +38,9 @@ export async function plantSeed({ userId, slot, inventoryId }) {
 
     await connection.query('DELETE FROM inventory WHERE id = ?', [inventoryNumber]);
     await connection.query(
-      'UPDATE plots SET type = ?, planted_at = NOW(), harvested = 0 WHERE user_id = ? AND slot = ?',
+      `UPDATE plots
+       SET type = ?, planted_at = NOW(), harvested = 0, matured_notified = 0
+       WHERE user_id = ? AND slot = ?`,
       [seed.type, userId, slotNumber]
     );
 

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -1,0 +1,82 @@
+import nodemailer from 'nodemailer';
+import config from '../config/index.js';
+import { logError, logInfo } from '../logging/index.js';
+
+let transporter;
+
+function buildTransportOptions() {
+  const authMissing = !config.email.user || !config.email.password;
+  const baseOptions = {
+    host: config.email.host,
+    port: config.email.port,
+    secure: config.email.secure
+  };
+
+  if (!authMissing) {
+    baseOptions.auth = {
+      user: config.email.user,
+      pass: config.email.password
+    };
+  }
+
+  return baseOptions;
+}
+
+function getTransporter() {
+  if (!config.email.enabled) {
+    return null;
+  }
+
+  if (transporter) {
+    return transporter;
+  }
+
+  transporter = nodemailer.createTransport(buildTransportOptions());
+  return transporter;
+}
+
+export async function sendEmail({ to, subject, text }) {
+  if (!config.email.enabled) {
+    logInfo('Email delivery disabled, skipping send', {
+      event: 'email.skip_disabled',
+      to,
+      subject
+    });
+    return false;
+  }
+
+  const mailer = getTransporter();
+  if (!mailer) {
+    logError('Email transport is not configured', {
+      event: 'email.transport_missing',
+      to,
+      subject
+    });
+    return false;
+  }
+
+  try {
+    await mailer.sendMail({
+      from: config.email.from,
+      to,
+      subject,
+      text
+    });
+
+    logInfo('Email sent', {
+      event: 'email.sent',
+      to,
+      subject
+    });
+    return true;
+  } catch (error) {
+    logError('Failed to send email', {
+      event: 'email.error',
+      to,
+      subject,
+      error: error.message,
+      stack: error.stack
+    });
+    return false;
+  }
+}

--- a/backend/src/workers/maturity-notifier.js
+++ b/backend/src/workers/maturity-notifier.js
@@ -1,0 +1,119 @@
+import config from '../config/index.js';
+import { query } from '../db/pool.js';
+import { logError, logInfo } from '../logging/index.js';
+import { sendEmail } from '../utils/email.js';
+
+let timer;
+let isRunning = false;
+
+async function fetchMaturePlots() {
+  const [rows] = await query(
+    `SELECT p.user_id AS userId, p.slot, p.type, p.planted_at AS plantedAt, u.email
+     FROM plots p
+     JOIN users u ON u.id = p.user_id
+     WHERE p.harvested = 0
+       AND p.type IS NOT NULL
+       AND p.planted_at IS NOT NULL
+       AND p.matured_notified = 0
+       AND TIMESTAMPDIFF(MINUTE, p.planted_at, NOW()) >= ?`,
+    [config.garden.growthMinutes]
+  );
+
+  return rows;
+}
+
+async function markAsNotified(userId, slot) {
+  await query('UPDATE plots SET matured_notified = 1 WHERE user_id = ? AND slot = ?', [userId, slot]);
+}
+
+async function notifyPlot(plot) {
+  const subject = 'Овощ созрел!';
+  const text = `Ваш урожай "${plot.type}" на грядке #${plot.slot} готов к сбору.`;
+
+  const delivered = await sendEmail({ to: plot.email, subject, text });
+  if (!delivered) {
+    return false;
+  }
+
+  await markAsNotified(plot.userId, plot.slot);
+  logInfo('Maturity notification delivered', {
+    event: 'garden.maturity.notified',
+    userId: plot.userId,
+    slot: plot.slot,
+    type: plot.type
+  });
+  return true;
+}
+
+async function checkMaturePlots() {
+  if (isRunning) {
+    return;
+  }
+
+  isRunning = true;
+  try {
+    const plots = await fetchMaturePlots();
+    for (const plot of plots) {
+      try {
+        await notifyPlot(plot);
+      } catch (error) {
+        logError('Failed to process maturity notification', {
+          event: 'garden.maturity.notify_failed',
+          userId: plot.userId,
+          slot: plot.slot,
+          error: error.message,
+          stack: error.stack
+        });
+      }
+    }
+  } catch (error) {
+    logError('Failed to check mature plots', {
+      event: 'garden.maturity.check_failed',
+      error: error.message,
+      stack: error.stack
+    });
+  } finally {
+    isRunning = false;
+  }
+}
+
+function scheduleNextRun(delayMs = config.scheduler.maturityCheckIntervalMs) {
+  if (timer) {
+    clearTimeout(timer);
+  }
+
+  timer = setTimeout(async () => {
+    await checkMaturePlots();
+    scheduleNextRun();
+  }, delayMs);
+
+  timer.unref();
+}
+
+export function startMaturityNotifier() {
+  if (!config.email.enabled) {
+    logInfo('Email notifications disabled, maturity notifier not started', {
+      event: 'garden.maturity.notifier.disabled'
+    });
+    return null;
+  }
+
+  if (timer) {
+    return timer;
+  }
+
+  logInfo('Starting maturity notifier', {
+    event: 'garden.maturity.notifier.start',
+    intervalMs: config.scheduler.maturityCheckIntervalMs
+  });
+
+  scheduleNextRun(0);
+  return timer;
+}
+
+export function stopMaturityNotifier() {
+  if (timer) {
+    clearTimeout(timer);
+    timer = undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- add SMTP configuration and email utility for sending notifications
- track plot notification status and schedule maturity checks to email users when crops ripen
- reset notification flags on planting, harvesting, and uprooting operations

## Testing
- not run (npm unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931fc61a0288320b69acc0dd04b84ec)