### PR TITLE
Add MailHog email sandbox for maturity alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ docker compose up --build
 
 - UI фермы — <http://localhost>
 - Swagger UI — <http://localhost/api/docs>
+- Почта (MailHog) — <http://localhost:8025>
 - OpenSearch Dashboards — <http://localhost/opensearch>
 - Kafka UI — <http://localhost:8080>
 
@@ -38,6 +39,7 @@ docker compose up --build
 | zookeeper | Координация Kafka | 2181 | 2181 |
 | kafka | Брокер сообщений для очереди посадки | 9092/29092 | 9092/29092 |
 | kafka-ui | UI для просмотра топиков Kafka | 8080 | 8080 |
+| mailhog | Тестовая SMTP-песочница и веб-интерфейс писем | 1025/8025 | 1025/8025 |
 | backend | REST API и миграции | 3000 | 3000 |
 | frontend | Статическая сборка SPA | 80 | 5173 |
 | nginx | Reverse proxy и единая точка входа | 80 | 80 |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,3 +35,10 @@ KAFKA_BROKERS=kafka:9092
 KAFKA_CLIENT_ID=ferm-backend
 KAFKA_CONSUMER_GROUP=ferm-plant-consumers
 KAFKA_PLANT_TOPIC=ferm.garden.plant
+
+# Почта для уведомлений (MailHog)
+EMAIL_ENABLED=true
+EMAIL_HOST=mailhog
+EMAIL_PORT=1025
+EMAIL_SECURE=false
+EMAIL_FROM=no-reply@ferma.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,12 +119,19 @@ services:
       KAFKA_CLIENT_ID: ferm-backend
       KAFKA_CONSUMER_GROUP: ferm-plant-consumers
       KAFKA_PLANT_TOPIC: ferm.garden.plant
+      EMAIL_ENABLED: "true"
+      EMAIL_HOST: mailhog
+      EMAIL_PORT: 1025
+      EMAIL_SECURE: "false"
+      EMAIL_FROM: no-reply@ferma.local
     depends_on:
       mysql:
         condition: service_healthy
       opensearch:
         condition: service_healthy
       kafka:
+        condition: service_started
+      mailhog:
         condition: service_started
     ports:
       - "3000:3000"
@@ -147,6 +154,14 @@ services:
         condition: service_healthy
     ports:
       - "5173:80"
+    restart: unless-stopped
+
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    container_name: ferm-mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
     restart: unless-stopped
 
   nginx:


### PR DESCRIPTION
## Summary
- add MailHog SMTP sandbox service to the docker compose stack and make backend depend on it
- provide default email configuration for notifications via MailHog in backend/.env.example and compose
- document the MailHog endpoints alongside the other developer services

## Testing
- npm test *(fails: npm not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693205cc76388320bfa1962269a11c14)