### PR TITLE
Fix email transport defaults for broad provider support

### DIFF
--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -105,7 +105,7 @@ const config = {
     enabled: toBool(process.env.EMAIL_ENABLED, false),
     host: getString(process.env.EMAIL_HOST, 'smtp'),
     port: toInt(process.env.EMAIL_PORT, 1025),
-    secure: toBool(process.env.EMAIL_SECURE, false),
+    secure: toBool(process.env.EMAIL_SECURE, undefined),
     user: getString(process.env.EMAIL_USER),
     password: getString(process.env.EMAIL_PASSWORD),
     from: getString(process.env.EMAIL_FROM, 'no-reply@ferma.local')

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -6,10 +6,11 @@ let transporter;
 
 function buildTransportOptions() {
   const authMissing = !config.email.user || !config.email.password;
+  const secure = config.email.secure ?? config.email.port === 465;
   const baseOptions = {
     host: config.email.host,
     port: config.email.port,
-    secure: config.email.secure
+    secure
   };
 
   if (!authMissing) {


### PR DESCRIPTION
## Summary
- allow EMAIL_SECURE to be left unset so we can infer secure transport settings
- automatically enable secure SMTP when using port 465 to work with common mail providers

## Testing
- npm test (fails: npm not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693208a41db883208664409e4c01c26f)