### PR TITLE
Ensure request and response codes included in HTTP logs

### DIFF
--- a/backend/src/middleware/request-logger.js
+++ b/backend/src/middleware/request-logger.js
@@ -130,7 +130,11 @@ export function requestLogger(req, res, next) {
 
   let requestPayload = null;
   if (baseRequestPayload) {
-    requestPayload = { ...baseRequestPayload, CodeRequest: requestCodes.CodeRequest };
+    requestPayload = {
+      ...baseRequestPayload,
+      CodeRequest: requestCodes.CodeRequest,
+      CodeResponse: requestCodes.CodeResponse
+    };
 
     const bodyForLogging = shouldRedactProfile ? redactProfilePayload(req.body) : req.body;
     const requestBody = serializeForLog(bodyForLogging, { allowEmptyObject: true });
@@ -179,6 +183,7 @@ export function requestLogger(req, res, next) {
         status: res.statusCode,
         durationMs,
         responseBody: responseBody ?? null,
+        CodeRequest: requestCodes.CodeRequest,
         CodeResponse: requestCodes.CodeResponse
       };
 


### PR DESCRIPTION
## Summary
- include both CodeRequest and CodeResponse in request log payloads
- attach request/response codes to response log entries for consistent observability

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69320caf44808320b595e313db781904)