### PR TITLE
Add IntegrationName keyword mapping for OpenSearch logs

### DIFF
--- a/backend/src/logging/index.js
+++ b/backend/src/logging/index.js
@@ -76,7 +76,8 @@ async function createIndexWithRetry(osClient) {
                 requestQuery: { type: 'text' },
                 requestParams: { type: 'text' },
                 stack: { type: 'text' },
-                responseBody: { type: 'text' }              
+                responseBody: { type: 'text' },
+                IntegrationName: { type: 'keyword' }
               }
             }
           }


### PR DESCRIPTION
## Summary
- add IntegrationName keyword mapping to the OpenSearch log index for filterable searches

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693211c680d48320acbc6e99c3b360a7)