### PR TITLE
Enable email notifications by default

### DIFF
--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -102,7 +102,7 @@ const config = {
     plantTopic: getString(process.env.KAFKA_PLANT_TOPIC, 'ferm.garden.plant')
   },
   email: {
-    enabled: toBool(process.env.EMAIL_ENABLED, false),
+    enabled: toBool(process.env.EMAIL_ENABLED, true),
     host: getString(process.env.EMAIL_HOST, 'smtp'),
     port: toInt(process.env.EMAIL_PORT, 1025),
     secure: toBool(process.env.EMAIL_SECURE, undefined),


### PR DESCRIPTION
## Summary
- enable email notifications by default so maturity notifier starts without extra configuration

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69321379f1b4832092ab91ea82148f2f)