### PR TITLE
Add IntegrationName tag to nginx logs

### DIFF
--- a/vector/vector.toml
+++ b/vector/vector.toml
@@ -21,6 +21,8 @@ if exists(.time) {
   if err == null { .["@timestamp"] = ts }
 }
 
+.IntegrationName = "Ferma"
+
 .source = "nginx"
 '''
 


### PR DESCRIPTION
## Summary
- add a default IntegrationName tag to nginx logs in the Vector pipeline so it is available for filtering in OpenSearch

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932142fd6f88320832d0372ee43acc2)