### PR TITLE
Add request/response codes to log mapping

### DIFF
--- a/backend/src/logging/index.js
+++ b/backend/src/logging/index.js
@@ -77,6 +77,8 @@ async function createIndexWithRetry(osClient) {
                 requestParams: { type: 'text' },
                 stack: { type: 'text' },
                 responseBody: { type: 'text' },
+                CodeRequest: { type: 'integer' },
+                CodeResponse: { type: 'integer' },
                 IntegrationName: { type: 'keyword' }
               }
             }


### PR DESCRIPTION
## Summary
- add CodeRequest and CodeResponse fields to the OpenSearch log index mapping to persist tags for request and response events

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69321aad393c8320bd6b1262ca3b5dcf)