### PR TITLE
Configure MailHog for email notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ docker compose up --build
 - Swagger UI — <http://localhost/api/docs>
 - OpenSearch Dashboards — <http://localhost/opensearch>
 - Kafka UI — <http://localhost:8080>
+- MailHog UI — <http://localhost:8025>
 
 Для корректной работы необходимо, чтобы в `backend/.env` и `frontend/.env`
 прописаны значения по примеру из соответствующих `*.env.example`.
@@ -38,6 +39,7 @@ docker compose up --build
 | zookeeper | Координация Kafka | 2181 | 2181 |
 | kafka | Брокер сообщений для очереди посадки | 9092/29092 | 9092/29092 |
 | kafka-ui | UI для просмотра топиков Kafka | 8080 | 8080 |
+| mailhog | Приёмщик почты для уведомлений | 1025/8025 | 1025/8025 |
 | backend | REST API и миграции | 3000 | 3000 |
 | frontend | Статическая сборка SPA | 80 | 5173 |
 | nginx | Reverse proxy и единая точка входа | 80 | 80 |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,3 +35,10 @@ KAFKA_BROKERS=kafka:9092
 KAFKA_CLIENT_ID=ferm-backend
 KAFKA_CONSUMER_GROUP=ferm-plant-consumers
 KAFKA_PLANT_TOPIC=ferm.garden.plant
+
+# Почта через MailHog
+EMAIL_ENABLED=true
+EMAIL_HOST=mailhog
+EMAIL_PORT=1025
+EMAIL_SECURE=false
+EMAIL_FROM="Ферма Артёма <no-reply@ferma.local>"

--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -103,7 +103,7 @@ const config = {
   },
   email: {
     enabled: toBool(process.env.EMAIL_ENABLED, true),
-    host: getString(process.env.EMAIL_HOST, 'smtp'),
+    host: getString(process.env.EMAIL_HOST, 'mailhog'),
     port: toInt(process.env.EMAIL_PORT, 1025),
     secure: toBool(process.env.EMAIL_SECURE, undefined),
     user: getString(process.env.EMAIL_USER),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,18 +120,18 @@ services:
       KAFKA_CONSUMER_GROUP: ferm-plant-consumers
       KAFKA_PLANT_TOPIC: ferm.garden.plant
       EMAIL_ENABLED: "true"
-      EMAIL_HOST: "smtp.yandex.ru"
-      EMAIL_PORT: "465"
-      EMAIL_SECURE: "true"
-      EMAIL_USER: "nkmchs88@yandex.ru"
-      EMAIL_PASSWORD: "ektsnuviwpkkhzrr"
-      EMAIL_FROM: "Ферма Артёма <nkmchs88@yandex.ru>"
+      EMAIL_HOST: mailhog
+      EMAIL_PORT: "1025"
+      EMAIL_SECURE: "false"
+      EMAIL_FROM: "Ферма Артёма <no-reply@ferma.local>"
     depends_on:
       mysql:
         condition: service_healthy
       opensearch:
         condition: service_healthy
       kafka:
+        condition: service_started
+      mailhog:
         condition: service_started
     ports:
       - "3000:3000"
@@ -143,6 +143,14 @@ services:
       timeout: 5s
       retries: 10
       start_period: 20s
+
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    container_name: ferm-mailhog
+    restart: unless-stopped
+    ports:
+      - "1025:1025"
+      - "8025:8025"
 
   frontend:
     build: ./frontend


### PR DESCRIPTION
## Summary
- route backend email notifications through the MailHog service defined in docker-compose
- set MailHog defaults for backend configuration and example environment variables
- document the MailHog UI availability alongside other services

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69321bdad5348320bc2a32b13af4e790)