### PR TITLE
Fix maturity notification consumers to run asynchronously

### DIFF
--- a/backend/src/services/maturity-consumer.js
+++ b/backend/src/services/maturity-consumer.js
@@ -140,7 +140,14 @@ export async function startMaturityConsumer() {
   }
 
   await consumer.subscribe({ topic: config.kafka.maturityTopic, fromBeginning: false });
-  await consumer.run({ eachMessage: createMaturityHandler() });
+
+  consumer.run({ eachMessage: createMaturityHandler() }).catch((error) => {
+    logError('Consumer созревания остановился с ошибкой', {
+      event: 'garden.maturity.consumer.crashed',
+      error: error.message,
+      stack: error.stack
+    });
+  });
 
   logInfo('Consumer созревания запущен', {
     event: 'garden.maturity.consumer.started',

--- a/backend/src/workers/plant-consumer.js
+++ b/backend/src/workers/plant-consumer.js
@@ -105,8 +105,15 @@ export async function startPlantConsumer() {
   }
 
   await consumer.subscribe({ topic: config.kafka.plantTopic, fromBeginning: false });
-  await consumer.run({
+
+  consumer.run({
     eachMessage: async (context) => handlePlantingMessage(context)
+  }).catch((error) => {
+    logError('Consumer посадки остановился с ошибкой', {
+      event: 'garden.plant.consumer.crashed',
+      error: error.message,
+      stack: error.stack
+    });
   });
 
   logInfo('Consumer посадки запущен', {


### PR DESCRIPTION
## Summary
- start the plant and maturity Kafka consumers without awaiting the long-running loops
- add crash logging so stalled consumers are visible and notifications continue to flow

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69322a3458488320877ef02e4b95fb31)